### PR TITLE
Remove detached views from the view hierarchy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 
 ## [Master](https://github.com/appwise-labs/StatefulUI)
 
+## [1.0.5](https://github.com/appwise-labs/StatefulUI/releases/tag/1.0.5)
+
+### Bug Fixes
+
+* Detached views are removed from the view hierarchy.
+* Fixed incorrect safe area insets.
+
 ## [1.0.4](https://github.com/appwise-labs/StatefulUI/releases/tag/1.0.4)
 
 ### New Features

--- a/Sources/Internals/PassthroughView.swift
+++ b/Sources/Internals/PassthroughView.swift
@@ -76,19 +76,21 @@ final class PassthroughView: UIView {
 	}
 
 	private func updatePositioning() {
-		var frame = superview?.bounds ?? .zero
+		DispatchQueue.main.async {
+			var frame = superview?.bounds ?? .zero
 
-		if let superview = superview as? UIScrollView {
-			if #available(iOS 11.0, *) {
-				frame = frame.inset(by: superview.safeAreaInsets)
-			} else {
-				frame = frame.inset(by: superview.contentInset)
+			if let superview = superview as? UIScrollView {
+				if #available(iOS 11.0, *) {
+					frame = frame.inset(by: superview.safeAreaInsets)
+				} else {
+					frame = frame.inset(by: superview.contentInset)
+				}
 			}
-		}
 
-		frame.origin = .zero
-		if frame != self.frame {
-			super.frame = frame
+			if frame != self.frame {
+				super.frame = frame
+			}
 		}
 	}
 }
+

--- a/StatefulUI.podspec
+++ b/StatefulUI.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
 	# info
 	s.name = 'StatefulUI'
-	s.version = '1.0.4'
+	s.version = '1.0.5'
 	s.summary = 'Placeholder views based on content, loading, error or empty states.'
 	s.description = <<-DESC
 	A protocol that presents placeholder views based on content, loading, error or empty states.


### PR DESCRIPTION
When using functions `addView(_:forState:)` and `removeViewForState(_)` the views currently assigned to those states are never removed from the view hierarchy. This leads to numerous "orphan" views in the view hierarchy.